### PR TITLE
StreamStore: add default URL parameter for the default graph

### DIFF
--- a/StreamStore.js
+++ b/StreamStore.js
@@ -67,6 +67,8 @@ class StreamStore {
 
       if (graph && graph.termType !== 'DefaultGraph') {
         url.searchParams.append('graph', graph.value)
+      } else {
+        url.searchParams.append('default', '')
       }
 
       const res = await this.client.fetch(url, {
@@ -97,6 +99,8 @@ class StreamStore {
 
     if (graph && graph.termType !== 'DefaultGraph') {
       url.searchParams.append('graph', graph.value)
+    } else {
+      url.searchParams.append('default', '')
     }
 
     const serialize = new Transform({

--- a/test/StreamStore.test.js
+++ b/test/StreamStore.test.js
@@ -84,11 +84,13 @@ describe('StreamStore', () => {
       })
     })
 
-    it('should not send the graph query parameter if the default graph is requested', async () => {
+    it('should send the default parameter if the default graph is requested', async () => {
       await withServer(async server => {
+        let defaultParameter = null
         let graphParameter = null
 
         server.app.get('/', async (req, res) => {
+          defaultParameter = req.query.default
           graphParameter = req.query.graph
 
           res.status(204).end()
@@ -101,6 +103,7 @@ describe('StreamStore', () => {
         const stream = store.read({ method: 'GET', graph: rdf.defaultGraph() })
         await chunks(stream)
 
+        strictEqual(defaultParameter, '')
         strictEqual(graphParameter, undefined)
       })
     })


### PR DESCRIPTION
My reading of the spec (https://www.w3.org/TR/2013/REC-sparql11-http-rdf-update-20130321/#http-put) indicates that ?default= should be added if graph= is not specified. At least one server (Oxigraph) rejects a request without ?default.
